### PR TITLE
Build pyinstaller on ubuntu-18.04

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
           path: ./dist/
           
   pyinstaller_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Get tag


### PR DESCRIPTION
Used ubuntu 18.04 instead of ubuntu-latest when building with pyinstaller.